### PR TITLE
Historical bars via broker market-data endpoints (Alpaca, Tradier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@luxalgo/broker-sdk` are documented here.
 
+## Unreleased
+
+### Added
+
+- Historical OHLCV bars: `connection.fetchBars(symbol, { timeframe, from, to, limit })` returns normalized `Bar[]` from the broker's own read-only market-data endpoints. Implemented for **Alpaca** (stocks on the IEX feed via `data.alpaca.markets` v2 bars, crypto pairs via v1beta3, `page_token` paging capped at 10,000 bars) and **Tradier** (intraday via `timesales`, daily via `history`, America/New_York timestamps converted with a DST-aware helper).
+- Schema: `Bar`, `BarTimeframe`, `BarsRequest`, `MAX_BARS`; optional `fetchBars` on `BrokerAdapter`.
+- `supportsBars(brokerId)` and a `supportsBars` flag on `listBrokers()` entries; `UnsupportedCapabilityError` for brokers without market-data endpoints or timeframes a venue cannot serve.
+
 ## 0.4.0
 
 - Six new adapters, 22 brokers total: **Charles Schwab** (bring-your-own OAuth2 app), **TradeStation** (bring-your-own OAuth2 app), **tastytrade** (rotating remember token), **Robinhood Crypto** (official API, Ed25519 request signing via node:crypto), **Gemini**, and **KuCoin**.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ console.log(stats.totalEquity, stats.trades?.winRate, stats.topPositions);
 
 One broker failing never takes down the sweep: failures come back alongside the snapshots that succeeded. The stats engine does FIFO round-trip matching, win rate, average win and loss, and per-symbol activity. A sell with no recorded buy is ignored, never guessed at.
 
+## Bars
+
+Brokers that publish their own market-data endpoints can serve historical OHLCV bars with the same read-only credentials, normalized to one shape (`time` is the bar open in epoch ms, oldest-first):
+
+```ts
+const alpaca = connect({ broker: "alpaca", credentials: { apiKey, apiSecret } });
+const from = Date.now() - 24 * 60 * 60 * 1000;
+const bars = await alpaca.fetchBars("AAPL", { timeframe: "1m", from, to: Date.now() });
+// [{ time, open, high, low, close, volume }, ...]
+await alpaca.fetchBars("BTC/USD", { timeframe: "1h", limit: 500 }); // crypto pairs carry a slash
+```
+
+Supported: **Alpaca** (stocks on the IEX feed, crypto pairs; `1m`, `5m`, `15m`, `1h`, `1d`) and **Tradier** (`1m`, `5m`, `15m` via timesales, `1d` via history). Other brokers have no market-data endpoint, so `fetchBars` rejects with `UnsupportedCapabilityError`; check ahead with `supportsBars(brokerId)` or the `supportsBars` flag on `listBrokers()`.
+
 ## Import any broker statement
 
 No API? Any account at any institution is importable from a trade-history CSV. The parser is tolerant on headers (brokers disagree on column names) and strict on rows (anything unreadable is skipped and counted, never guessed):
@@ -89,31 +103,31 @@ const positions = positionsFromTrades(trades);
 
 ## Supported brokers
 
-| Broker | Credentials | Trades history |
-| --- | --- | :---: |
-| Alpaca (live + paper) | API key + secret | ✅ |
-| Binance | API key + secret (read-only) | ➖ |
-| Bybit | API key + secret (read-only) | ➖ |
-| Charles Schwab | your own OAuth2 app | ✅ |
-| Coinbase | your own OAuth2 app (read scope) | ➖ |
-| Crypto.com Exchange | API key + secret (read-only) | ➖ |
-| E\*TRADE | your own OAuth 1.0a app | ✅ |
-| Gemini | API key + secret (auditor role) | ➖ |
-| Hyperliquid | wallet address only | ✅ |
-| Interactive Brokers (Flex) | Flex token + query ID | ✅ |
-| Kraken | API key + secret ("Query Funds") | ➖ |
-| KuCoin | API key + secret + passphrase (read) | ✅ |
-| OKX | API key + secret + passphrase (read) | ➖ |
-| Public.com | API secret key | ✅ |
-| Questrade | API refresh token | ✅ |
-| Robinhood Crypto | API key + Ed25519 private key | ✅ |
-| tastytrade | login (rotating remember token) | ✅ |
-| Topstep (ProjectX) | username + API key | ✅ |
-| TradeStation | your own OAuth2 app | ➖ |
-| Tradier | access token | ✅ |
-| Trading212 | API key | ➖ |
-| Webull (OpenAPI) | App key + secret | ➖ |
-| Any broker via CSV import | a statement file | ✅ |
+| Broker | Credentials | Trades history | Bars |
+| --- | --- | :---: | :---: |
+| Alpaca (live + paper) | API key + secret | ✅ | ✅ |
+| Binance | API key + secret (read-only) | ➖ | ➖ |
+| Bybit | API key + secret (read-only) | ➖ | ➖ |
+| Charles Schwab | your own OAuth2 app | ✅ | ➖ |
+| Coinbase | your own OAuth2 app (read scope) | ➖ | ➖ |
+| Crypto.com Exchange | API key + secret (read-only) | ➖ | ➖ |
+| E\*TRADE | your own OAuth 1.0a app | ✅ | ➖ |
+| Gemini | API key + secret (auditor role) | ➖ | ➖ |
+| Hyperliquid | wallet address only | ✅ | ➖ |
+| Interactive Brokers (Flex) | Flex token + query ID | ✅ | ➖ |
+| Kraken | API key + secret ("Query Funds") | ➖ | ➖ |
+| KuCoin | API key + secret + passphrase (read) | ✅ | ➖ |
+| OKX | API key + secret + passphrase (read) | ➖ | ➖ |
+| Public.com | API secret key | ✅ | ➖ |
+| Questrade | API refresh token | ✅ | ➖ |
+| Robinhood Crypto | API key + Ed25519 private key | ✅ | ➖ |
+| tastytrade | login (rotating remember token) | ✅ | ➖ |
+| Topstep (ProjectX) | username + API key | ✅ | ➖ |
+| TradeStation | your own OAuth2 app | ➖ | ➖ |
+| Tradier | access token | ✅ | ✅ |
+| Trading212 | API key | ➖ | ➖ |
+| Webull (OpenAPI) | App key + secret | ➖ | ➖ |
+| Any broker via CSV import | a statement file | ✅ | ➖ |
 
 `listBrokers()` returns every adapter with its exact credential fields and a one-line guide to creating the key with **read-only scope**, which is all this SDK ever needs.
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -38,6 +38,24 @@ One shape for everything, regardless of broker. This document is the human-reada
 | `fee?` | `number` | Commission/fee, absolute value, only when reported and non-zero. |
 | `executedAt?` | `string` | ISO 8601, only when the source carried a parseable timestamp. |
 
+### Bar
+
+Historical OHLCV, returned by `connection.fetchBars(symbol, request)` for brokers whose adapter implements the optional `fetchBars` capability (Alpaca, Tradier). Bars come oldest-first.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `time` | `number` | Bar open, epoch milliseconds UTC. Daily bars open at midnight America/New_York on both brokers (Alpaca reports it that way; Tradier's dates are converted). |
+| `open` / `high` / `low` / `close` | `number` | In the venue's quote currency. A row missing any of the four, or internally inconsistent (open or close outside `[low, high]`), is dropped, never patched. |
+| `volume?` | `number` | Only when the venue reports it for the bar. |
+
+### BarsRequest
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `timeframe` | `"1m" \| "5m" \| "15m" \| "1h" \| "1d"` | Only resolutions the venue serves natively — adapters never resample. Tradier has no hourly interval and rejects `"1h"` with `UnsupportedCapabilityError`. |
+| `from?` / `to?` | `number` | Window bounds, epoch milliseconds. Broker defaults apply when omitted. |
+| `limit?` | `number` | Keeps the most recent `limit` bars of the window. Every call is capped at `MAX_BARS` (10,000) regardless. |
+
 ### BrokerSnapshot
 
 The envelope `fetchSnapshot()` returns: `{ broker, fetchedAt, accounts }`. Plain JSON — persist it however you like.

--- a/src/adapters/alpaca-bars.ts
+++ b/src/adapters/alpaca-bars.ts
@@ -1,0 +1,119 @@
+import { MissingCredentialsError } from "../errors.js";
+import type { Bar, BarTimeframe, BarsRequest } from "../schema.js";
+import { buildBar, effectiveBarLimit, finalizeBars } from "./bars.js";
+import { asFiniteNumber, rejectResponse } from "./http.js";
+import type { Credentials, FetchContext } from "./types.js";
+
+/*
+  Alpaca historical bars. Market data lives on its own host
+  (data.alpaca.markets) shared by live and paper keys, so unlike the
+  account endpoints there is no host to pick from the key prefix — the same
+  headers authenticate either kind. Stocks use /v2/stocks/{symbol}/bars,
+  crypto pairs (anything with a "/", e.g. BTC/USD) use the v1beta3 crypto
+  endpoint, which keys its response by symbol. Both are read-only
+  market-data endpoints: the read-only contract of this SDK still holds.
+
+  The IEX feed is the default because it is included with every account;
+  SIP requires a paid data subscription and would fail for most users.
+*/
+
+export const ALPACA_DATA_API = "https://data.alpaca.markets";
+/** Alpaca's per-page maximum. */
+const PAGE_SIZE = 10_000;
+/** Guard against a broker that keeps handing back page tokens. */
+const MAX_PAGES = 50;
+
+const ALPACA_TIMEFRAMES: Record<BarTimeframe, string> = {
+  "1m": "1Min",
+  "5m": "5Min",
+  "15m": "15Min",
+  "1h": "1Hour",
+  "1d": "1Day",
+};
+
+/** Alpaca spells crypto symbols with a slash (BTC/USD); stocks never carry one. */
+export const isAlpacaCryptoSymbol = (symbol: string): boolean => symbol.includes("/");
+
+export type AlpacaBarRow = {
+  /** RFC 3339 bar open. */
+  t?: string;
+  o?: number | string;
+  h?: number | string;
+  l?: number | string;
+  c?: number | string;
+  v?: number | string;
+};
+
+type AlpacaStockBarsPage = { bars?: AlpacaBarRow[] | null; next_page_token?: string | null };
+type AlpacaCryptoBarsPage = { bars?: Record<string, AlpacaBarRow[] | null> | null; next_page_token?: string | null };
+
+/**
+ * Pure mapper from Alpaca bar rows (all pages concatenated) to normalized
+ * bars. Rows with an unparseable timestamp or incomplete OHLC drop out.
+ */
+export const normalizeAlpacaBars = (rows: AlpacaBarRow[], request: BarsRequest): Bar[] => {
+  const bars: Bar[] = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const parsedTime = row.t ? Date.parse(row.t) : Number.NaN;
+    const bar = buildBar(
+      Number.isNaN(parsedTime) ? undefined : parsedTime,
+      asFiniteNumber(row.o),
+      asFiniteNumber(row.h),
+      asFiniteNumber(row.l),
+      asFiniteNumber(row.c),
+      asFiniteNumber(row.v),
+    );
+    if (bar) bars.push(bar);
+  }
+  return finalizeBars(bars, request);
+};
+
+/** Query string for one bars page; exported so the wire format is testable. */
+export const alpacaBarsQuery = (symbol: string, request: BarsRequest, pageToken?: string): URLSearchParams => {
+  const params = new URLSearchParams();
+  if (isAlpacaCryptoSymbol(symbol)) params.set("symbols", symbol);
+  params.set("timeframe", ALPACA_TIMEFRAMES[request.timeframe]);
+  if (request.from !== undefined) params.set("start", new Date(request.from).toISOString());
+  if (request.to !== undefined) params.set("end", new Date(request.to).toISOString());
+  params.set("limit", String(Math.min(effectiveBarLimit(request), PAGE_SIZE)));
+  // Newest-first so a small `limit` yields the most recent bars; the
+  // normalizer restores chronological order.
+  params.set("sort", "desc");
+  if (!isAlpacaCryptoSymbol(symbol)) params.set("feed", "iex");
+  if (pageToken) params.set("page_token", pageToken);
+  return params;
+};
+
+export const fetchAlpacaBars = async (
+  credentials: Credentials,
+  symbol: string,
+  request: BarsRequest,
+  ctx: FetchContext,
+): Promise<Bar[]> => {
+  const apiKey = credentials.apiKey?.trim();
+  const apiSecret = credentials.apiSecret?.trim();
+  if (!apiKey || !apiSecret) {
+    throw new MissingCredentialsError("alpaca", "Alpaca connection is missing its API key or secret");
+  }
+  const trimmed = symbol.trim().toUpperCase();
+  const crypto = isAlpacaCryptoSymbol(trimmed);
+  const path = crypto ? "/v1beta3/crypto/us/bars" : `/v2/stocks/${encodeURIComponent(trimmed)}/bars`;
+  const cap = effectiveBarLimit(request);
+
+  const rows: AlpacaBarRow[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < MAX_PAGES && rows.length < cap; page += 1) {
+    const response = await ctx.fetch(`${ALPACA_DATA_API}${path}?${alpacaBarsQuery(trimmed, request, pageToken)}`, {
+      headers: { "APCA-API-KEY-ID": apiKey, "APCA-API-SECRET-KEY": apiSecret },
+    });
+    if (!response.ok) rejectResponse("alpaca", "Alpaca", response);
+    const body = (await response.json()) as AlpacaStockBarsPage | AlpacaCryptoBarsPage;
+    const pageRows = crypto
+      ? ((body as AlpacaCryptoBarsPage).bars?.[trimmed] ?? [])
+      : ((body as AlpacaStockBarsPage).bars ?? []);
+    rows.push(...pageRows);
+    pageToken = body.next_page_token ?? undefined;
+    if (!pageToken || pageRows.length === 0) break;
+  }
+  return normalizeAlpacaBars(rows, request);
+};

--- a/src/adapters/alpaca.ts
+++ b/src/adapters/alpaca.ts
@@ -1,5 +1,6 @@
 import { MissingCredentialsError } from "../errors.js";
 import type { Account, AssetClass, Trade } from "../schema.js";
+import { fetchAlpacaBars } from "./alpaca-bars.js";
 import { asFiniteNumber, asIsoTimestamp, rejectResponse } from "./http.js";
 import type { BrokerAdapter, Credentials, FetchContext } from "./types.js";
 
@@ -153,4 +154,5 @@ export const alpaca: BrokerAdapter<AlpacaRaw> = {
     "Generate an API key in the Alpaca dashboard (paper keys start with PK and work too); the SDK only ever calls account, position, and activity endpoints.",
   fetchRaw,
   normalize,
+  fetchBars: fetchAlpacaBars,
 };

--- a/src/adapters/bars.ts
+++ b/src/adapters/bars.ts
@@ -1,0 +1,54 @@
+import { MAX_BARS, type Bar, type BarsRequest } from "../schema.js";
+
+/*
+  Helpers shared by every bar-capable adapter, all pure. Normalizers hand
+  back bars oldest-first with duplicates on the same open time collapsed
+  (keep-last, since brokers re-send a still-forming bar), and `limit`
+  keeps the most recent bars so the semantics match across venues that
+  page from the start (Alpaca) and venues that return the whole window at
+  once (Tradier).
+*/
+
+/** Effective cap for one request: the caller's `limit`, never above `MAX_BARS`. */
+export const effectiveBarLimit = (request: BarsRequest): number => {
+  const limit = request.limit;
+  if (limit === undefined || !Number.isFinite(limit) || limit <= 0) return MAX_BARS;
+  return Math.min(Math.floor(limit), MAX_BARS);
+};
+
+/** Sort oldest-first, collapse same-time duplicates, keep the most recent `limit`. */
+export const finalizeBars = (bars: Bar[], request: BarsRequest): Bar[] => {
+  const byTime = new Map<number, Bar>();
+  for (const bar of bars) byTime.set(bar.time, bar);
+  const sorted = [...byTime.values()].sort((a, b) => a.time - b.time);
+  const limit = effectiveBarLimit(request);
+  return sorted.length > limit ? sorted.slice(sorted.length - limit) : sorted;
+};
+
+/**
+ * Build one bar from already-parsed numbers, or nothing when any OHLC
+ * value is missing or the bar is internally inconsistent (high below low,
+ * open or close outside the range). Volume is optional and dropped when
+ * negative or unparseable — omitted, never guessed.
+ */
+export const buildBar = (
+  time: number | undefined,
+  open: number | undefined,
+  high: number | undefined,
+  low: number | undefined,
+  close: number | undefined,
+  volume: number | undefined,
+): Bar | undefined => {
+  if (time === undefined || open === undefined || high === undefined || low === undefined || close === undefined) {
+    return undefined;
+  }
+  if (high < low || open > high || open < low || close > high || close < low) return undefined;
+  return {
+    time,
+    open,
+    high,
+    low,
+    close,
+    ...(volume !== undefined && volume >= 0 ? { volume } : {}),
+  };
+};

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -24,6 +24,14 @@ import type { BrokerAdapter } from "./types.js";
 
 export type { BrokerAdapter, Credentials, FetchContext, AdapterFetchResult } from "./types.js";
 export { alpaca, alpacaHostForKey, parseAlpacaFills, type AlpacaRaw } from "./alpaca.js";
+export {
+  alpacaBarsQuery,
+  fetchAlpacaBars,
+  isAlpacaCryptoSymbol,
+  normalizeAlpacaBars,
+  type AlpacaBarRow,
+} from "./alpaca-bars.js";
+export { buildBar, effectiveBarLimit, finalizeBars } from "./bars.js";
 export { binance, type BinanceRaw } from "./binance.js";
 export { bybit, type BybitRaw } from "./bybit.js";
 export {
@@ -63,6 +71,19 @@ export { tastytrade, type TastytradeRaw } from "./tastytrade.js";
 export { topstep, parseTopstepTrades, topstepSymbol, type TopstepRaw } from "./topstep.js";
 export { tradestation, type TradestationRaw } from "./tradestation.js";
 export { tradier, parseTradierHistory, tradierList, type TradierRaw } from "./tradier.js";
+export {
+  etOffsetAt,
+  etToEpochMs,
+  fetchTradierBars,
+  formatTradierEtTime,
+  normalizeTradierBars,
+  parseTradierEtTime,
+  tradierBarsQuery,
+  type TradierHistoryResponse,
+  type TradierHistoryRow,
+  type TradierTimesaleRow,
+  type TradierTimesalesResponse,
+} from "./tradier-bars.js";
 export { trading212, trading212Symbol, type Trading212Raw } from "./trading212.js";
 export { webull, buildWebullStringToSign, webullListIn, type WebullRaw } from "./webull.js";
 

--- a/src/adapters/tradier-bars.ts
+++ b/src/adapters/tradier-bars.ts
@@ -1,0 +1,187 @@
+import { MissingCredentialsError, UnsupportedCapabilityError } from "../errors.js";
+import type { Bar, BarTimeframe, BarsRequest } from "../schema.js";
+import { buildBar, finalizeBars } from "./bars.js";
+import { asFiniteNumber, rejectResponse } from "./http.js";
+import { tradierList } from "./tradier-list.js";
+import type { Credentials, FetchContext } from "./types.js";
+
+/*
+  Tradier historical bars. Intraday comes from /v1/markets/timesales
+  (interval 1min/5min/15min, `session_filter=all` so pre/post-market bars
+  are included) and daily from /v1/markets/history. Both are read-only
+  market-data endpoints on the production host: the read-only contract of
+  this SDK still holds. Tradier has no hourly interval, so "1h" is refused
+  rather than resampled — the SDK never invents bars.
+
+  Every Tradier timestamp is a zone-less wall-clock string in
+  America/New_York ("2024-03-08T09:30:00", "2024-03-08"), and the
+  start/end query parameters are expected in the same form. The offset
+  helpers below encode the US DST rule in force since 2007 (second Sunday
+  of March to first Sunday of November, switching at 02:00 local) so the
+  conversion needs no timezone library and no runtime tz database.
+*/
+
+const TRADIER_MARKETS_API = "https://api.tradier.com/v1/markets";
+
+const TRADIER_INTERVALS: Partial<Record<BarTimeframe, string>> = {
+  "1m": "1min",
+  "5m": "5min",
+  "15m": "15min",
+};
+
+const HOUR = 3_600_000;
+const EST_OFFSET = 5 * HOUR;
+const EDT_OFFSET = 4 * HOUR;
+
+/** UTC instant of the n-th (1-based) given weekday (0 = Sunday) of a month, at 00:00 UTC. */
+const nthWeekdayUtc = (year: number, month: number, weekday: number, n: number): number => {
+  const first = Date.UTC(year, month, 1);
+  const shift = (weekday - new Date(first).getUTCDay() + 7) % 7;
+  return first + (shift + 7 * (n - 1)) * 24 * HOUR;
+};
+
+/** DST window for a year as UTC instants: [start, end). Springs forward at 02:00 EST, falls back at 02:00 EDT. */
+const dstWindowUtc = (year: number): { start: number; end: number } => ({
+  start: nthWeekdayUtc(year, 2, 0, 2) + 2 * HOUR + EST_OFFSET,
+  end: nthWeekdayUtc(year, 10, 0, 1) + 2 * HOUR + EDT_OFFSET,
+});
+
+/** Offset to subtract from an ET wall-clock reading to reach UTC, at a UTC instant. */
+export const etOffsetAt = (utcMs: number): number => {
+  const { start, end } = dstWindowUtc(new Date(utcMs).getUTCFullYear());
+  return utcMs >= start && utcMs < end ? EDT_OFFSET : EST_OFFSET;
+};
+
+/**
+ * Convert an ET wall-clock time to epoch ms. The ambiguous fall-back hour
+ * resolves to its first (EDT) occurrence; the skipped spring-forward hour
+ * is read as EST, which lands it on the same real instant as the clock
+ * that jumped ahead.
+ */
+export const etToEpochMs = (
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): number => {
+  const wall = Date.UTC(year, month - 1, day, hour, minute, second);
+  const { start, end } = dstWindowUtc(year);
+  const asEdt = wall + EDT_OFFSET;
+  return asEdt >= start && asEdt < end ? asEdt : wall + EST_OFFSET;
+};
+
+const TRADIER_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/;
+
+/** Parse a Tradier ET wall-clock string ("2024-03-08T09:30:00" or "2024-03-08") to epoch ms. */
+export const parseTradierEtTime = (value: string | undefined | null): number | undefined => {
+  if (!value) return undefined;
+  const match = TRADIER_TIME_PATTERN.exec(value.trim());
+  if (!match) return undefined;
+  const [, y, mo, d, h, mi, s] = match;
+  return etToEpochMs(Number(y), Number(mo), Number(d), Number(h ?? 0), Number(mi ?? 0), Number(s ?? 0));
+};
+
+const pad = (value: number): string => String(value).padStart(2, "0");
+
+/** Format an epoch ms instant as Tradier's ET query parameter, with or without the clock. */
+export const formatTradierEtTime = (epochMs: number, withClock: boolean): string => {
+  const wall = new Date(epochMs - etOffsetAt(epochMs));
+  const date = `${wall.getUTCFullYear()}-${pad(wall.getUTCMonth() + 1)}-${pad(wall.getUTCDate())}`;
+  return withClock ? `${date} ${pad(wall.getUTCHours())}:${pad(wall.getUTCMinutes())}` : date;
+};
+
+export type TradierTimesaleRow = {
+  time?: string;
+  open?: number | string;
+  high?: number | string;
+  low?: number | string;
+  close?: number | string;
+  volume?: number | string;
+};
+export type TradierHistoryRow = {
+  date?: string;
+  open?: number | string;
+  high?: number | string;
+  low?: number | string;
+  close?: number | string;
+  volume?: number | string;
+};
+
+export type TradierTimesalesResponse = { series?: { data?: TradierTimesaleRow | TradierTimesaleRow[] } | "null" | null };
+export type TradierHistoryResponse = { history?: { day?: TradierHistoryRow | TradierHistoryRow[] } | "null" | null };
+
+/**
+ * Pure mapper from either Tradier bars payload to normalized bars. Daily
+ * bars open at midnight ET, matching Alpaca's daily `t`. Rows with an
+ * unparseable time or incomplete OHLC drop out.
+ */
+export const normalizeTradierBars = (
+  payload: TradierTimesalesResponse | TradierHistoryResponse,
+  request: BarsRequest,
+): Bar[] => {
+  const series = (payload as TradierTimesalesResponse).series;
+  const history = (payload as TradierHistoryResponse).history;
+  const rows: (TradierTimesaleRow | TradierHistoryRow)[] = [
+    ...tradierList(typeof series === "object" ? series?.data : undefined),
+    ...tradierList(typeof history === "object" ? history?.day : undefined),
+  ];
+  const bars: Bar[] = [];
+  for (const row of rows) {
+    const time = parseTradierEtTime("time" in row ? row.time : (row as TradierHistoryRow).date);
+    const bar = buildBar(
+      time,
+      asFiniteNumber(row.open),
+      asFiniteNumber(row.high),
+      asFiniteNumber(row.low),
+      asFiniteNumber(row.close),
+      asFiniteNumber(row.volume),
+    );
+    if (bar) bars.push(bar);
+  }
+  return finalizeBars(bars, request);
+};
+
+/** Endpoint path and query for one request; exported so the wire format is testable. */
+export const tradierBarsQuery = (symbol: string, request: BarsRequest): { path: string; params: URLSearchParams } => {
+  const params = new URLSearchParams({ symbol });
+  if (request.timeframe === "1d") {
+    params.set("interval", "daily");
+    if (request.from !== undefined) params.set("start", formatTradierEtTime(request.from, false));
+    if (request.to !== undefined) params.set("end", formatTradierEtTime(request.to, false));
+    return { path: "/history", params };
+  }
+  const interval = TRADIER_INTERVALS[request.timeframe];
+  if (!interval) {
+    throw new UnsupportedCapabilityError(
+      "tradier",
+      "fetchBars",
+      `Tradier has no "${request.timeframe}" interval; use 1m, 5m, 15m, or 1d`,
+    );
+  }
+  params.set("interval", interval);
+  params.set("session_filter", "all");
+  if (request.from !== undefined) params.set("start", formatTradierEtTime(request.from, true));
+  if (request.to !== undefined) params.set("end", formatTradierEtTime(request.to, true));
+  return { path: "/timesales", params };
+};
+
+export const fetchTradierBars = async (
+  credentials: Credentials,
+  symbol: string,
+  request: BarsRequest,
+  ctx: FetchContext,
+): Promise<Bar[]> => {
+  const { accessToken } = credentials;
+  if (!accessToken) {
+    throw new MissingCredentialsError("tradier", "Tradier connection is missing its access token");
+  }
+  const { path, params } = tradierBarsQuery(symbol.trim().toUpperCase(), request);
+  const response = await ctx.fetch(`${TRADIER_MARKETS_API}${path}?${params}`, {
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: "application/json" },
+  });
+  if (!response.ok) rejectResponse("tradier", "Tradier", response);
+  const payload = (await response.json()) as TradierTimesalesResponse | TradierHistoryResponse;
+  return normalizeTradierBars(payload, request);
+};

--- a/src/adapters/tradier-list.ts
+++ b/src/adapters/tradier-list.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalize Tradier's object-or-array-or-null collections to an array.
+ * Tradier quirk: single-element collections come back as a bare object
+ * instead of an array, empty ones as null or the string "null".
+ */
+export const tradierList = <T>(value: T | T[] | null | undefined | "null"): T[] => {
+  if (value === null || value === undefined || value === "null") return [];
+  return Array.isArray(value) ? value : [value];
+};

--- a/src/adapters/tradier.ts
+++ b/src/adapters/tradier.ts
@@ -1,6 +1,8 @@
 import { MissingCredentialsError, BrokerRequestError } from "../errors.js";
 import type { Account, Position, Trade } from "../schema.js";
 import { asFiniteNumber, asIsoTimestamp, rejectResponse } from "./http.js";
+import { fetchTradierBars } from "./tradier-bars.js";
+import { tradierList } from "./tradier-list.js";
 import type { BrokerAdapter, Credentials, FetchContext } from "./types.js";
 
 /*
@@ -13,11 +15,7 @@ import type { BrokerAdapter, Credentials, FetchContext } from "./types.js";
 
 const TRADIER_API = "https://api.tradier.com/v1";
 
-/** Normalize Tradier's object-or-array-or-null collections to an array. */
-export const tradierList = <T>(value: T | T[] | null | undefined | "null"): T[] => {
-  if (value === null || value === undefined || value === "null") return [];
-  return Array.isArray(value) ? value : [value];
-};
+export { tradierList } from "./tradier-list.js";
 
 type TradierHistoryEvent = {
   type?: string;
@@ -158,4 +156,5 @@ export const tradier: BrokerAdapter<TradierRaw> = {
     "Copy the API access token from Tradier account settings; the SDK only calls profile, balance, position, and history endpoints.",
   fetchRaw,
   normalize,
+  fetchBars: fetchTradierBars,
 };

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,4 +1,4 @@
-import type { Account, CredentialField } from "../schema.js";
+import type { Account, Bar, BarsRequest, CredentialField } from "../schema.js";
 
 export type Credentials = Record<string, string>;
 
@@ -25,7 +25,10 @@ export type AdapterFetchResult<Raw> = {
  *   adapter's mapping is testable without a network or credentials.
  *
  * Read-only by contract: `fetchRaw` must only ever call account, balance,
- * position, and history endpoints — never trading ones.
+ * position, and history endpoints — never trading ones. The optional
+ * `fetchBars` extends that list with the broker's own market-data
+ * endpoints, which are read-only too; adapters whose broker has no such
+ * endpoints simply leave it undefined.
  */
 export type BrokerAdapter<Raw = unknown> = {
   id: string;
@@ -36,4 +39,11 @@ export type BrokerAdapter<Raw = unknown> = {
   readOnlySetup: string;
   fetchRaw: (credentials: Credentials, ctx: FetchContext) => Promise<AdapterFetchResult<Raw>>;
   normalize: (raw: Raw) => Account[];
+  /**
+   * Historical OHLCV bars for one symbol, using the same read-only
+   * credentials. Only present when the broker exposes market-data
+   * endpoints; `connect()` turns its absence into an
+   * `UnsupportedCapabilityError` so callers can feature-detect either way.
+   */
+  fetchBars?: (credentials: Credentials, symbol: string, request: BarsRequest, ctx: FetchContext) => Promise<Bar[]>;
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -36,3 +36,18 @@ export class BrokerRequestError extends BrokerError {
     if (status !== undefined) this.status = status;
   }
 }
+
+/**
+ * The adapter does not implement an optional capability (e.g. `fetchBars`
+ * on a broker with no market-data endpoints), or does not support the
+ * requested variant of it (a timeframe the venue cannot serve).
+ */
+export class UnsupportedCapabilityError extends BrokerError {
+  readonly capability: string;
+
+  constructor(broker: string, capability: string, message: string) {
+    super(broker, message);
+    this.name = "UnsupportedCapabilityError";
+    this.capability = capability;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { adapters, getAdapter, type AnyBrokerAdapter, type BrokerId } from "./adapters/index.js";
 import type { Credentials, FetchContext } from "./adapters/types.js";
-import { BrokerError } from "./errors.js";
-import type { BrokerSnapshot, CredentialField } from "./schema.js";
+import { BrokerError, UnsupportedCapabilityError } from "./errors.js";
+import type { Bar, BarsRequest, BrokerSnapshot, CredentialField } from "./schema.js";
 
 export * from "./schema.js";
 export * from "./errors.js";
@@ -63,7 +63,17 @@ export type BrokerConnection = {
   readonly credentials: Credentials;
   /** Fetch a fresh normalized snapshot straight from the broker. */
   fetchSnapshot: () => Promise<BrokerSnapshot>;
+  /**
+   * Historical OHLCV bars from the broker's own market-data endpoints, with
+   * the same read-only credentials. Always present on the object; rejects
+   * with `UnsupportedCapabilityError` when the broker has no such endpoints
+   * (check ahead with `supportsBars(broker)`).
+   */
+  fetchBars: (symbol: string, request: BarsRequest) => Promise<Bar[]>;
 };
+
+/** Whether a broker's adapter can serve historical bars. */
+export const supportsBars = (broker: BrokerId): boolean => typeof getAdapter(broker)?.fetchBars === "function";
 
 /**
  * Open a connection to one broker with the user's own credentials.
@@ -95,6 +105,17 @@ const createConnection = (adapter: AnyBrokerAdapter, options: ConnectOptions): B
     };
   };
 
+  const fetchBars = async (symbol: string, request: BarsRequest): Promise<Bar[]> => {
+    if (!adapter.fetchBars) {
+      throw new UnsupportedCapabilityError(
+        adapter.id,
+        "fetchBars",
+        `${adapter.displayName} exposes no market-data endpoint for historical bars`,
+      );
+    }
+    return adapter.fetchBars(credentials, symbol, request, ctx);
+  };
+
   return {
     broker: adapter.id as BrokerId,
     label: options.label ?? adapter.displayName,
@@ -102,6 +123,7 @@ const createConnection = (adapter: AnyBrokerAdapter, options: ConnectOptions): B
       return { ...credentials };
     },
     fetchSnapshot,
+    fetchBars,
   };
 };
 
@@ -155,6 +177,8 @@ export type BrokerInfo = {
   displayName: string;
   credentials: CredentialField[];
   readOnlySetup: string;
+  /** True when `connection.fetchBars` is backed by a real market-data endpoint. */
+  supportsBars: boolean;
 };
 
 /** Every supported broker with its credential fields and read-only setup guide. */
@@ -166,5 +190,6 @@ export const listBrokers = (): BrokerInfo[] =>
       displayName: adapter.displayName,
       credentials: adapter.credentials,
       readOnlySetup: adapter.readOnlySetup,
+      supportsBars: typeof adapter.fetchBars === "function",
     };
   });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -87,3 +87,37 @@ export type CredentialField = {
   /** True for secrets (API secrets, tokens); false for public identifiers. */
   secret: boolean;
 };
+
+/**
+ * Bar resolution. Deliberately small: these are the timeframes every
+ * bar-capable broker can serve directly, so no adapter ever has to resample.
+ */
+export type BarTimeframe = "1m" | "5m" | "15m" | "1h" | "1d";
+
+/** One OHLCV bar. `time` is the bar's open, epoch milliseconds UTC. */
+export type Bar = {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  /** Omitted when the venue does not report volume for the bar. */
+  volume?: number;
+};
+
+/** A request for historical bars of one symbol. */
+export type BarsRequest = {
+  timeframe: BarTimeframe;
+  /** Inclusive window start, epoch milliseconds. Broker default when omitted. */
+  from?: number;
+  /** Window end, epoch milliseconds. Broker default when omitted. */
+  to?: number;
+  /**
+   * Maximum number of bars; when the window holds more, the most recent
+   * `limit` bars are kept. Always capped at `MAX_BARS` regardless.
+   */
+  limit?: number;
+};
+
+/** Hard ceiling on bars returned by one `fetchBars` call, whatever `limit` says. */
+export const MAX_BARS = 10_000;

--- a/tests/bars.test.ts
+++ b/tests/bars.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+
+import { alpacaBarsQuery, isAlpacaCryptoSymbol, normalizeAlpacaBars } from "../src/adapters/alpaca-bars.js";
+import { finalizeBars } from "../src/adapters/bars.js";
+import {
+  etOffsetAt,
+  etToEpochMs,
+  formatTradierEtTime,
+  normalizeTradierBars,
+  parseTradierEtTime,
+  tradierBarsQuery,
+} from "../src/adapters/tradier-bars.js";
+import { MissingCredentialsError, UnsupportedCapabilityError } from "../src/errors.js";
+import { connect, listBrokers, supportsBars, MAX_BARS } from "../src/index.js";
+
+/** Records every URL a connection hits and serves canned bodies in order. */
+const recordingFetch = (bodies: unknown[]) => {
+  const urls: string[] = [];
+  const fetch = ((url: string | URL) => {
+    urls.push(String(url));
+    const body = bodies[Math.min(urls.length - 1, bodies.length - 1)];
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  }) as typeof globalThis.fetch;
+  return { fetch, urls };
+};
+
+describe("normalizing Alpaca bars", () => {
+  const rows = [
+    { t: "2024-03-08T14:31:00Z", o: 171.2, h: 171.4, l: 171.1, c: 171.3, v: 1200, n: 40, vw: 171.25 },
+    { t: "2024-03-08T14:30:00Z", o: "171.0", h: "171.3", l: "170.9", c: "171.2", v: "2400" },
+    { t: "not-a-date", o: 1, h: 2, l: 0.5, c: 1.5, v: 1 },
+    { t: "2024-03-08T14:32:00Z", o: 171.3, h: 171.5, l: 171.2 },
+    { t: "2024-03-08T14:33:00Z", o: 175, h: 171.5, l: 171.2, c: 171.4, v: 10 },
+  ];
+
+  it("maps vendor rows to oldest-first bars, parsing RFC 3339 to epoch ms and dropping bad rows", () => {
+    expect(normalizeAlpacaBars(rows, { timeframe: "1m" })).toEqual([
+      { time: Date.UTC(2024, 2, 8, 14, 30), open: 171.0, high: 171.3, low: 170.9, close: 171.2, volume: 2400 },
+      { time: Date.UTC(2024, 2, 8, 14, 31), open: 171.2, high: 171.4, low: 171.1, close: 171.3, volume: 1200 },
+    ]);
+  });
+
+  it("keeps the most recent `limit` bars and returns nothing for empty or null pages", () => {
+    expect(normalizeAlpacaBars(rows, { timeframe: "1m", limit: 1 })).toEqual([
+      { time: Date.UTC(2024, 2, 8, 14, 31), open: 171.2, high: 171.4, low: 171.1, close: 171.3, volume: 1200 },
+    ]);
+    expect(normalizeAlpacaBars([], { timeframe: "1d" })).toEqual([]);
+    expect(normalizeAlpacaBars(null as never, { timeframe: "1d" })).toEqual([]);
+  });
+
+  it("omits volume when the venue does not report it", () => {
+    const [bar] = normalizeAlpacaBars([{ t: "2024-03-08T05:00:00Z", o: 1, h: 2, l: 1, c: 2 }], { timeframe: "1d" });
+    expect(bar).toEqual({ time: Date.UTC(2024, 2, 8, 5), open: 1, high: 2, low: 1, close: 2 });
+    expect(bar).not.toHaveProperty("volume");
+  });
+
+  it("collapses a re-sent forming bar onto its final value and honors the hard cap", () => {
+    const first = { time: 1, open: 1, high: 2, low: 1, close: 1.5 };
+    const again = { time: 1, open: 1, high: 3, low: 1, close: 2.5 };
+    expect(finalizeBars([first, again], { timeframe: "1m" })).toEqual([again]);
+    const many = Array.from({ length: MAX_BARS + 5 }, (_, i) => ({ time: i, open: 1, high: 1, low: 1, close: 1 }));
+    const capped = finalizeBars(many, { timeframe: "1m", limit: MAX_BARS * 2 });
+    expect(capped).toHaveLength(MAX_BARS);
+    expect(capped[0]?.time).toBe(5);
+  });
+
+  it("speaks Alpaca's wire format: timeframe names, IEX feed for stocks, symbols param for crypto", () => {
+    const stock = alpacaBarsQuery("AAPL", {
+      timeframe: "15m",
+      from: Date.UTC(2024, 2, 8, 14, 30),
+      to: Date.UTC(2024, 2, 8, 21),
+      limit: 50,
+    });
+    expect(Object.fromEntries(stock)).toEqual({
+      timeframe: "15Min",
+      start: "2024-03-08T14:30:00.000Z",
+      end: "2024-03-08T21:00:00.000Z",
+      limit: "50",
+      sort: "desc",
+      feed: "iex",
+    });
+    const crypto = alpacaBarsQuery("BTC/USD", { timeframe: "1h" }, "tok");
+    expect(crypto.get("symbols")).toBe("BTC/USD");
+    expect(crypto.get("timeframe")).toBe("1Hour");
+    expect(crypto.get("feed")).toBeNull();
+    expect(crypto.get("page_token")).toBe("tok");
+    expect(crypto.get("limit")).toBe(String(MAX_BARS));
+    expect(alpacaBarsQuery("SPY", { timeframe: "1d" }).get("timeframe")).toBe("1Day");
+    expect(isAlpacaCryptoSymbol("ETH/USD")).toBe(true);
+    expect(isAlpacaCryptoSymbol("ETHUSD")).toBe(false);
+  });
+});
+
+describe("Eastern Time without a timezone library", () => {
+  it("switches offsets at the 2024 spring-forward instant (2:00 EST, March 10)", () => {
+    expect(etOffsetAt(Date.UTC(2024, 2, 10, 6, 59))).toBe(5 * 3_600_000);
+    expect(etOffsetAt(Date.UTC(2024, 2, 10, 7, 0))).toBe(4 * 3_600_000);
+  });
+
+  it("switches back at the 2024 fall-back instant (2:00 EDT, November 3)", () => {
+    expect(etOffsetAt(Date.UTC(2024, 10, 3, 5, 59))).toBe(4 * 3_600_000);
+    expect(etOffsetAt(Date.UTC(2024, 10, 3, 6, 0))).toBe(5 * 3_600_000);
+  });
+
+  it("converts wall-clock ET to epoch ms on both sides of each boundary", () => {
+    expect(etToEpochMs(2024, 3, 10, 1, 59)).toBe(Date.UTC(2024, 2, 10, 6, 59));
+    expect(etToEpochMs(2024, 3, 10, 3, 0)).toBe(Date.UTC(2024, 2, 10, 7, 0));
+    // The skipped 02:30 reads as EST — the same instant the jumped clock shows as 03:30 EDT.
+    expect(etToEpochMs(2024, 3, 10, 2, 30)).toBe(Date.UTC(2024, 2, 10, 7, 30));
+    // The repeated hour resolves to its first (EDT) occurrence.
+    expect(etToEpochMs(2024, 11, 3, 1, 30)).toBe(Date.UTC(2024, 10, 3, 5, 30));
+    expect(etToEpochMs(2024, 11, 3, 2, 0)).toBe(Date.UTC(2024, 10, 3, 7, 0));
+    // A different year moves the boundary: DST started March 9 in 2025.
+    expect(etToEpochMs(2025, 3, 9, 3, 0)).toBe(Date.UTC(2025, 2, 9, 7, 0));
+    expect(etToEpochMs(2025, 3, 8, 9, 30)).toBe(Date.UTC(2025, 2, 8, 14, 30));
+  });
+
+  it("parses Tradier's zone-less strings and formats query parameters back in ET", () => {
+    expect(parseTradierEtTime("2024-03-08T09:30:00")).toBe(Date.UTC(2024, 2, 8, 14, 30));
+    expect(parseTradierEtTime("2024-07-01T09:30:00")).toBe(Date.UTC(2024, 6, 1, 13, 30));
+    expect(parseTradierEtTime("2024-03-08")).toBe(Date.UTC(2024, 2, 8, 5));
+    expect(parseTradierEtTime("2024-07-01")).toBe(Date.UTC(2024, 6, 1, 4));
+    expect(parseTradierEtTime("yesterday")).toBeUndefined();
+    expect(parseTradierEtTime(undefined)).toBeUndefined();
+    expect(formatTradierEtTime(Date.UTC(2024, 6, 1, 13, 30), true)).toBe("2024-07-01 09:30");
+    expect(formatTradierEtTime(Date.UTC(2024, 2, 8, 14, 30), true)).toBe("2024-03-08 09:30");
+    // 03:00 UTC on March 9 is still the evening of March 8 in New York.
+    expect(formatTradierEtTime(Date.UTC(2024, 2, 9, 3), false)).toBe("2024-03-08");
+  });
+});
+
+describe("normalizing Tradier bars", () => {
+  it("maps timesales rows across a DST boundary, dropping rows with unreadable times or partial OHLC", () => {
+    const payload = {
+      series: {
+        data: [
+          { time: "2024-03-08T15:59:00", timestamp: 1709931540, price: 170.5, open: 170.4, high: 170.6, low: 170.3, close: 170.5, volume: 900, vwap: 170.45 },
+          { time: "2024-03-11T09:30:00", timestamp: 1710163800, price: 172, open: "171.9", high: "172.2", low: "171.8", close: "172.0", volume: "3100", vwap: 172 },
+          { time: "", open: 1, high: 2, low: 1, close: 1, volume: 1 },
+          { time: "2024-03-11T09:31:00", open: 172, high: 172.1, low: 171.9, volume: 5 },
+        ],
+      },
+    };
+    expect(normalizeTradierBars(payload, { timeframe: "1m" })).toEqual([
+      { time: Date.UTC(2024, 2, 8, 20, 59), open: 170.4, high: 170.6, low: 170.3, close: 170.5, volume: 900 },
+      { time: Date.UTC(2024, 2, 11, 13, 30), open: 171.9, high: 172.2, low: 171.8, close: 172.0, volume: 3100 },
+    ]);
+  });
+
+  it("maps daily history rows to midnight ET opens and unwraps single-row and null collections", () => {
+    const single = { history: { day: { date: "2024-03-08", open: 169, high: 171, low: 168.5, close: 170.7, volume: 50_000_000 } } };
+    expect(normalizeTradierBars(single, { timeframe: "1d" })).toEqual([
+      { time: Date.UTC(2024, 2, 8, 5), open: 169, high: 171, low: 168.5, close: 170.7, volume: 50_000_000 },
+    ]);
+    expect(normalizeTradierBars({ history: null }, { timeframe: "1d" })).toEqual([]);
+    expect(normalizeTradierBars({ history: "null" }, { timeframe: "1d" })).toEqual([]);
+    expect(normalizeTradierBars({ series: { data: null } } as never, { timeframe: "1m" })).toEqual([]);
+    expect(normalizeTradierBars({} as never, { timeframe: "1m" })).toEqual([]);
+  });
+
+  it("keeps the most recent `limit` bars", () => {
+    const payload = {
+      history: {
+        day: [
+          { date: "2024-03-06", open: 1, high: 2, low: 1, close: 2, volume: 1 },
+          { date: "2024-03-07", open: 2, high: 3, low: 2, close: 3, volume: 1 },
+          { date: "2024-03-08", open: 3, high: 4, low: 3, close: 4, volume: 1 },
+        ],
+      },
+    };
+    expect(normalizeTradierBars(payload, { timeframe: "1d", limit: 2 }).map((bar) => bar.open)).toEqual([2, 3]);
+  });
+
+  it("routes intraday to timesales with session_filter=all and daily to history, refusing 1h", () => {
+    const intraday = tradierBarsQuery("AAPL", {
+      timeframe: "5m",
+      from: Date.UTC(2024, 2, 8, 14, 30),
+      to: Date.UTC(2024, 2, 8, 21),
+    });
+    expect(intraday.path).toBe("/timesales");
+    expect(Object.fromEntries(intraday.params)).toEqual({
+      symbol: "AAPL",
+      interval: "5min",
+      session_filter: "all",
+      start: "2024-03-08 09:30",
+      end: "2024-03-08 16:00",
+    });
+    const daily = tradierBarsQuery("AAPL", { timeframe: "1d", from: Date.UTC(2024, 0, 2, 5) });
+    expect(daily.path).toBe("/history");
+    expect(Object.fromEntries(daily.params)).toEqual({ symbol: "AAPL", interval: "daily", start: "2024-01-02" });
+    expect(() => tradierBarsQuery("AAPL", { timeframe: "1h" })).toThrow(UnsupportedCapabilityError);
+  });
+});
+
+describe("connection.fetchBars()", () => {
+  it("pages Alpaca stock bars with page_token on the market-data host and returns them oldest-first", async () => {
+    const { fetch, urls } = recordingFetch([
+      { bars: [{ t: "2024-03-08T14:31:00Z", o: 2, h: 3, l: 2, c: 3, v: 1 }], next_page_token: "p2", symbol: "AAPL" },
+      { bars: [{ t: "2024-03-08T14:30:00Z", o: 1, h: 2, l: 1, c: 2, v: 1 }], next_page_token: null, symbol: "AAPL" },
+    ]);
+    const connection = connect({ broker: "alpaca", credentials: { apiKey: "PKTEST", apiSecret: "s" }, fetch });
+    const bars = await connection.fetchBars("aapl", { timeframe: "1m", from: Date.UTC(2024, 2, 8, 14, 30) });
+    expect(bars.map((bar) => bar.time)).toEqual([Date.UTC(2024, 2, 8, 14, 30), Date.UTC(2024, 2, 8, 14, 31)]);
+    expect(urls).toHaveLength(2);
+    const first = new URL(urls[0]!);
+    expect(first.origin).toBe("https://data.alpaca.markets");
+    expect(first.pathname).toBe("/v2/stocks/AAPL/bars");
+    expect(first.searchParams.get("feed")).toBe("iex");
+    expect(first.searchParams.get("timeframe")).toBe("1Min");
+    expect(first.searchParams.get("page_token")).toBeNull();
+    expect(new URL(urls[1]!).searchParams.get("page_token")).toBe("p2");
+  });
+
+  it("stops paging Alpaca once `limit` bars are in hand", async () => {
+    const page = {
+      bars: [
+        { t: "2024-03-08T14:32:00Z", o: 1, h: 2, l: 1, c: 2, v: 1 },
+        { t: "2024-03-08T14:31:00Z", o: 1, h: 2, l: 1, c: 2, v: 1 },
+      ],
+      next_page_token: "more",
+    };
+    const { fetch, urls } = recordingFetch([page, page]);
+    const connection = connect({ broker: "alpaca", credentials: { apiKey: "AK", apiSecret: "s" }, fetch });
+    const bars = await connection.fetchBars("AAPL", { timeframe: "1m", limit: 2 });
+    expect(urls).toHaveLength(1);
+    expect(new URL(urls[0]!).searchParams.get("limit")).toBe("2");
+    expect(bars).toHaveLength(2);
+  });
+
+  it("uses the v1beta3 crypto endpoint for slash pairs and reads the per-symbol map", async () => {
+    const { fetch, urls } = recordingFetch([
+      { bars: { "BTC/USD": [{ t: "2024-03-08T00:00:00Z", o: 66000, h: 67000, l: 65500, c: 66800, v: 12.5 }] } },
+    ]);
+    const connection = connect({ broker: "alpaca", credentials: { apiKey: "AK", apiSecret: "s" }, fetch });
+    const bars = await connection.fetchBars("BTC/USD", { timeframe: "1d" });
+    expect(bars).toEqual([{ time: Date.UTC(2024, 2, 8), open: 66000, high: 67000, low: 65500, close: 66800, volume: 12.5 }]);
+    const url = new URL(urls[0]!);
+    expect(url.pathname).toBe("/v1beta3/crypto/us/bars");
+    expect(url.searchParams.get("symbols")).toBe("BTC/USD");
+    expect(url.searchParams.get("feed")).toBeNull();
+  });
+
+  it("fetches Tradier intraday bars from timesales with ET-formatted bounds", async () => {
+    const { fetch, urls } = recordingFetch([
+      { series: { data: [{ time: "2024-07-01T09:30:00", open: 1, high: 2, low: 1, close: 2, volume: 10 }] } },
+    ]);
+    const connection = connect({ broker: "tradier", credentials: { accessToken: "t" }, fetch });
+    const bars = await connection.fetchBars("AAPL", {
+      timeframe: "15m",
+      from: Date.UTC(2024, 6, 1, 13, 30),
+      to: Date.UTC(2024, 6, 1, 20),
+    });
+    expect(bars).toEqual([{ time: Date.UTC(2024, 6, 1, 13, 30), open: 1, high: 2, low: 1, close: 2, volume: 10 }]);
+    const url = new URL(urls[0]!);
+    expect(url.origin + url.pathname).toBe("https://api.tradier.com/v1/markets/timesales");
+    expect(url.searchParams.get("interval")).toBe("15min");
+    expect(url.searchParams.get("session_filter")).toBe("all");
+    expect(url.searchParams.get("start")).toBe("2024-07-01 09:30");
+    expect(url.searchParams.get("end")).toBe("2024-07-01 16:00");
+  });
+
+  it("fetches Tradier daily bars from history", async () => {
+    const { fetch, urls } = recordingFetch([{ history: { day: [{ date: "2024-07-01", open: 1, high: 2, low: 1, close: 2, volume: 3 }] } }]);
+    const connection = connect({ broker: "tradier", credentials: { accessToken: "t" }, fetch });
+    await connection.fetchBars("AAPL", { timeframe: "1d" });
+    const url = new URL(urls[0]!);
+    expect(url.pathname).toBe("/v1/markets/history");
+    expect(url.searchParams.get("interval")).toBe("daily");
+  });
+
+  it("refuses before any network call when credentials are missing or the timeframe is unsupported", async () => {
+    const untouchable = (() => {
+      throw new Error("network must not be touched");
+    }) as typeof globalThis.fetch;
+    const tradier = connect({ broker: "tradier", credentials: { accessToken: "t" }, fetch: untouchable });
+    await expect(tradier.fetchBars("AAPL", { timeframe: "1h" })).rejects.toBeInstanceOf(UnsupportedCapabilityError);
+    const alpaca = connect({ broker: "alpaca", credentials: { apiKey: "", apiSecret: "" }, fetch: untouchable });
+    await expect(alpaca.fetchBars("AAPL", { timeframe: "1m" })).rejects.toBeInstanceOf(MissingCredentialsError);
+  });
+
+  it("throws a typed unsupported error for brokers without market-data endpoints", async () => {
+    const connection = connect({
+      broker: "kraken",
+      credentials: { apiKey: "k", apiSecret: "cw==" },
+      fetch: (() => {
+        throw new Error("network must not be touched");
+      }) as typeof globalThis.fetch,
+    });
+    expect(typeof connection.fetchBars).toBe("function");
+    const error = await connection.fetchBars("BTC/USD", { timeframe: "1d" }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(UnsupportedCapabilityError);
+    expect(error).toMatchObject({ broker: "kraken", capability: "fetchBars" });
+  });
+
+  it("advertises the capability per broker", () => {
+    expect(supportsBars("alpaca")).toBe(true);
+    expect(supportsBars("tradier")).toBe(true);
+    expect(supportsBars("kraken")).toBe(false);
+    const flags = Object.fromEntries(listBrokers().map((broker) => [broker.id, broker.supportsBars]));
+    expect(flags.alpaca).toBe(true);
+    expect(flags.tradier).toBe(true);
+    expect(flags.binance).toBe(false);
+  });
+});

--- a/tests/connect-core.test.ts
+++ b/tests/connect-core.test.ts
@@ -21,12 +21,14 @@ const fakeBrokers: BrokerInfo[] = [
       { key: "note", label: "Connection note (optional)", secret: false },
     ],
     readOnlySetup: "Create a read-only key in the fake dashboard.",
+    supportsBars: true,
   },
   {
     id: "kraken",
     displayName: "Fake Kraken",
     credentials: [{ key: "apiKey", label: "API key", secret: true }],
     readOnlySetup: "Read-only scope only.",
+    supportsBars: false,
   },
 ];
 


### PR DESCRIPTION
## What

An optional bars capability: `connection.fetchBars(symbol, { timeframe, from, to, limit })` returns normalized OHLCV bars from the broker's own read-only market-data endpoints, using the credentials the user already holds. Implemented for **Alpaca** (stocks via `data.alpaca.markets/v2/stocks/{symbol}/bars`, `feed=iex`, `page_token` paging; crypto via `/v1beta3/crypto/us/bars` when the symbol contains `/`) and **Tradier** (1m/5m/15m via `/v1/markets/timesales` with `session_filter=all`; 1d via `/v1/markets/history`). Every other adapter rejects with a typed `UnsupportedCapabilityError`, so callers feature-detect with `supportsBars(broker)` or handle the error.

The first consumer is [Trade Relay](https://github.com/LuxAlgo/trade-relay/pull/1), which draws fills on the tape with Vela and needs candles from the brokers it executes on.

## Public API

- `Bar = { time /* bar open, epoch ms UTC */, open, high, low, close, volume? }`, `BarTimeframe = "1m" | "5m" | "15m" | "1h" | "1d"`, `BarsRequest = { timeframe, from?, to?, limit? }`, `MAX_BARS = 10_000`
- `BrokerConnection.fetchBars(symbol, request)`, always present, rejects with `UnsupportedCapabilityError extends BrokerError` (`capability` field) when the adapter lacks it
- `supportsBars(broker)`, and `BrokerInfo.supportsBars` on every `listBrokers()` entry
- `BrokerAdapter.fetchBars?` optional adapter capability, split like the rest of the SDK into a raw fetch and a pure `normalize*Bars` per adapter; the `/adapters` export exposes the pure pieces for testing

Semantics across both brokers: bars oldest-first, same-time duplicates collapsed keep-last, `limit` keeps the most recent N. Tradier's `1h` is refused rather than resampled. Tradier's Eastern-time strings are converted with a small hand-rolled DST rule (no tz dependency; the SDK stays zero-dependency); daily bars open at midnight ET, matching Alpaca's daily `t`.

Read-only contract holds: these are market-data endpoints only, never trading ones; the comments say so.

## Checks

`pnpm typecheck`, `pnpm build` (dist exports smoke-tested), `pnpm check`, `pnpm test`: 17 files, 176 tests, 21 new in `tests/bars.test.ts` covering both normalizers with vendor-shaped rows, paging, empty and null payloads, Tradier single-object collections, ET conversion across the 2024 spring-forward and fall-back instants plus a 2025 boundary, wire-format queries, connection-level tests with injected fetch (Alpaca stock paging, limit stop, crypto; Tradier intraday and daily), and the unsupported path for Kraken and Binance. No real endpoints were called. DCO signed.

Docs: `docs/SCHEMA.md` (Bar, BarsRequest), README "Bars" subsection plus a Bars column in the broker table, CHANGELOG (Unreleased / Added). Version not bumped.

## Notes

- `tradierList` moved to `src/adapters/tradier-list.ts` to avoid a module cycle; still re-exported, nothing public changed.
- No conformance vector added: the conformance gate covers account `normalize` only. Extending the vector format to bars is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N)_