### PR TITLE
Release 0.5.0: historical bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@luxalgo/broker-sdk` are documented here.
 
-## Unreleased
+## 0.5.0
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxalgo/broker-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Open-source broker connectivity for code, apps, and AI agents. 22 brokers, one normalized schema, zero dependencies. Your keys never leave your machine.",
   "license": "MIT",
   "author": "LuxAlgo Global, LLC",


### PR DESCRIPTION
## What

Version bump to 0.5.0 and the changelog's Unreleased section becomes the 0.5.0 entry. The release carries [#5](https://github.com/LuxAlgo/broker-sdk/pull/5): `connection.fetchBars` for Alpaca and Tradier, the `Bar` schema, `supportsBars`, and `UnsupportedCapabilityError`. A new public capability, so a minor bump.

## Publishing

Per `publish.yml`: after this merges, the `v0.5.0` tag is pushed and the workflow verifies the tag matches `package.json`, runs typecheck, tests, and build, then publishes to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N)_