### PR TITLE
tests: wait for the daemon sweep to deliver instead of a fixed 25 ms

### DIFF
--- a/tests/sync-daemon.test.ts
+++ b/tests/sync-daemon.test.ts
@@ -173,22 +173,35 @@ describe("createSyncDaemon", () => {
     const dir = await makeTmpDir();
     const statePath = path.join(dir, "state.json");
     const connection = stubConnection("alpaca", makeSnapshot());
+    const sink = capturingSink();
     const daemon = createSyncDaemon({
       connections: [connection],
-      sinks: [],
+      sinks: [sink],
       statePath,
       intervalSeconds: 60,
       now: fixedNow(),
     });
 
+    // A tick that fires mid-sweep joins the running sweep, so the clock must
+    // not advance until the previous sweep has delivered. Poll for that on
+    // the real setTimeout (left unfaked here) instead of sleeping a fixed
+    // 25 ms, which was flaky on a loaded CI runner.
+    const sweepsDelivered = async (n: number): Promise<void> => {
+      for (let i = 0; i < 400 && sink.batches.length < n; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(sink.batches.length).toBe(n);
+    };
+
     await daemon.start();
     expect(connection.fetches).toBe(1);
+    await sweepsDelivered(1);
 
     await vi.advanceTimersByTimeAsync(60_000);
-    await settle();
+    await sweepsDelivered(2);
     expect(connection.fetches).toBe(2);
     await vi.advanceTimersByTimeAsync(60_000);
-    await settle();
+    await sweepsDelivered(3);
     expect(connection.fetches).toBe(3);
 
     await daemon.stop();


### PR DESCRIPTION
## What

The interval-tick test in `tests/sync-daemon.test.ts` advanced the fake clock, slept a fixed 25 ms on the real clock, and asserted the fetch count. On the first 0.5.0 publish attempt that sleep was too short on the runner: the count read 2 where 3 was expected, and `npm publish`'s `prepublishOnly` check failed on it (the job's own `pnpm test` step had passed on the same commit a minute earlier).

The test now attaches a capturing sink and polls, on the real `setTimeout` the test leaves unfaked, until each sweep has delivered before advancing the clock again. That is the signal the test actually depends on: a tick that fires mid-sweep joins the running sweep (`inFlight ??=` in `daemon.ts`), so advancing the clock before the previous sweep has finished coalesces the next tick away. Polling on the fetch count alone was not enough for exactly that reason, and `vi.waitFor` cannot be used because it polls on the faked `setInterval`.

## Checks

Six consecutive runs of the file pass; `pnpm check` passes (17 files, 176 tests). DCO signed. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N)_