### PR TITLE
publish: npm 11 for Trusted Publishing, no empty token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      # npm Trusted Publishing needs npm 11.5+ for the OIDC exchange; Node 22
+      # ships npm 10, which cannot and falls back to asking for a token.
+      - run: npm install -g npm@latest && npm --version
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm test
@@ -55,7 +58,8 @@ jobs:
           fi
       - name: Verify pack contents
         run: npm pack --dry-run --ignore-scripts
+      # Trusted Publishing (OIDC): no token. The workflow's id-token: write
+      # permission is what npm verifies. An empty NODE_AUTH_TOKEN from an
+      # unset secret would make npm skip OIDC, so none is passed here.
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

The first publish run for 0.5.0 ([run 33713680376](https://github.com/LuxAlgo/broker-sdk/actions/runs/33713680376)) passed typecheck, tests, build, and pack, then failed at `npm publish` with `ENEEDAUTH`, even though the package has a Trusted Publisher configured for this workflow.

Two causes in the workflow, both fixed here:

- **npm 10.** `actions/setup-node` with Node 22 ships npm 10.9, which cannot perform npm's OIDC trusted-publishing exchange (npm 11.5+ required) and falls back to asking for a token. The job now runs `npm install -g npm@latest` before publishing and prints the version.
- **An empty token.** `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` with no such secret hands npm an empty token, which makes it skip OIDC even on a capable npm. The env line is removed; the job's `id-token: write` permission is what npm verifies.

## After merge

Dispatch `publish.yml` on main (already at 0.5.0). `--provenance` stays; with OIDC it is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQE5MdN51MXNXV15pZ9k5N)_